### PR TITLE
Fix loading bots from config

### DIFF
--- a/src/modules.ts
+++ b/src/modules.ts
@@ -136,7 +136,7 @@ export class ModuleManager {
     const c = this.config
     const bots: BotMap = {}
     const mods = await Promise.all(c.mods.map(mod => this.getPackageMain(mod)))
-    for (const [name, bot] of Object.values(c.bots)) {
+    for (const [name, bot] of Object.entries(c.bots)) {
       if (bot.startsWith('.')) {
         bots[name] = bot
       } else {


### PR DESCRIPTION
Currently iterating `values` instead of `entries` on the `bots` section of the config.  As a result, it treats the `[name, bot]` assignment as a string split, leaving `name` with the first character of the bot's path and `bot` with the second character.  Switching to `entries` restores the intended behavior.